### PR TITLE
Wrong opening quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SVG Weirdness
 
-**A repository for documenting bugs and other weird SVG behaviors, inspired by [Scott Jehl’s ”Device Bugs” repo](https://github.com/scottjehl/Device-Bugs).**
+**A repository for documenting bugs and other weird SVG behaviors, inspired by [Scott Jehl’s “Device Bugs” repo](https://github.com/scottjehl/Device-Bugs).**
 
-This is not necessarily meant to be a full list of bugs in SVG implementations, but a the very least a list of bugs and other ”gotchas” primarily in browsers that are not likely to be upgraded (older WebKit-based browsers on Android, older IE browser versions etc).
+This is not necessarily meant to be a full list of bugs in SVG implementations, but a the very least a list of bugs and other “gotchas” primarily in browsers that are not likely to be upgraded (older WebKit-based browsers on Android, older IE browser versions etc).
 
 All SVG issues are welcome though, as long as they are accompanied by documentation of which browser engines and version numbers they affect.


### PR DESCRIPTION
All in the name.

Simple "quotes" or curly “quotes”, but not ”quotes”.
